### PR TITLE
Added support for Oracle with Service Name and some support of multi-module projects.

### DIFF
--- a/src/main/java/com/wakaleo/schemaspy/SchemaSpyReport.java
+++ b/src/main/java/com/wakaleo/schemaspy/SchemaSpyReport.java
@@ -17,28 +17,28 @@ import com.wakaleo.schemaspy.util.JDBCHelper;
 
 /**
  * The SchemaSpy Maven plugin report.
- * 
+ *
  * @author John Smart
  * @mainpage The SchemaSpy Maven plugin This plugin is designed to generate
  *           SchemaSpy reports for a Maven web site.
- * 
+ *
  *           SchemaSpy (http://schemaspy.sourceforge.net) does not need to be
  *           installed and accessible on your machine. However, SchemaSpy also
  *           needs the Graphviz tool (http://www.graphviz.org/) in order to
  *           generate graphical representations of the table/view relationships,
  *           so this needs to be installed on your machine.
- * 
+ *
  *           The schemaspy goal invokes the SchemaSpy command-line tool.
  *           SchemaSpy generates a graphical and HTML report describing a given
  *           relational database.
- * 
+ *
  * @goal schemaspy
  */
 public class SchemaSpyReport extends AbstractMavenReport {
 
 	/**
 	 * The output directory for the intermediate report.
-	 * 
+	 *
 	 * @parameter expression="${project.build.directory}"
 	 * @required
 	 */
@@ -49,7 +49,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	 * that the reports are always generated in a directory called "schemaspy".
 	 * The output directory refers to the directory in which the "schemaspy"
 	 * will be generated.
-	 * 
+	 *
 	 * @parameter expression="${project.reporting.outputDirectory}"
 	 *            default-value="${project.build.directory}/site"
 	 * @required
@@ -58,14 +58,14 @@ public class SchemaSpyReport extends AbstractMavenReport {
 
 	/**
 	 * Site rendering component for generating the HTML report.
-	 * 
+	 *
 	 * @component
 	 */
 	private Renderer siteRenderer;
 
 	/**
 	 * The Maven project object.
-	 * 
+	 *
 	 * @parameter expression="${project}"
 	 * @required
 	 * @readonly
@@ -74,7 +74,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 
 	/**
 	 * The name of the database being analysed.
-	 * 
+	 *
 	 * @parameter database
 	 * @required
 	 */
@@ -82,14 +82,14 @@ public class SchemaSpyReport extends AbstractMavenReport {
 
 	/**
 	 * The host address of the database being analysed.
-	 * 
+	 *
 	 * @parameter host
 	 */
 	private String host;
 
 	/**
 	 * The port, required by some drivers.
-	 * 
+	 *
 	 * @parameter port
 	 */
 	private String port;
@@ -102,7 +102,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	 * result, is not needed). Note that you still need to specify the database
 	 * type, since SchemaSpy uses its own database properties file for extra
 	 * information about each database.
-	 * 
+	 *
 	 * @todo Would it be possible to guess the database type from the form of
 	 *       the URL?
 	 * @parameter jdbcUrl
@@ -111,28 +111,28 @@ public class SchemaSpyReport extends AbstractMavenReport {
 
 	/**
 	 * The type of database being analysed - defaults to ora.
-	 * 
+	 *
 	 * @parameter databaseType
 	 */
 	private String databaseType;
 
 	/**
 	 * Connect to the database with this user id.
-	 * 
+	 *
 	 * @parameter user
 	 */
 	private String user;
 
 	/**
 	 * Database schema to use - defaults to the specified user.
-	 * 
+	 *
 	 * @parameter schema
 	 */
 	private String schema;
 
 	/**
 	 * Database password to use - defaults to none.
-	 * 
+	 *
 	 * @parameter password
 	 */
 	private String password;
@@ -141,7 +141,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	 * If specified, SchemaSpy will look for JDBC drivers on this path, rather
 	 * than using the application classpath. Useful if your database has a
 	 * non-O/S driver not bundled with the plugin.
-	 * 
+	 *
 	 * @parameter pathToDrivers
 	 */
 	private String pathToDrivers;
@@ -151,7 +151,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	 * pages. If your description includes an equals sign then escape it with a
 	 * backslash. NOTE: This field doesn't seem to be used by SchemaSpy in the
 	 * current version.
-	 * 
+	 *
 	 * @parameter schemaDescription
 	 */
 	private String schemaDescription;
@@ -162,7 +162,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	 * "(.*book.*)|(library.*)" includes only those tables/views with 'book' in
 	 * their names or that start with 'library'. You might want to use
 	 * "description" with this option to describe the subset of tables.
-	 * 
+	 *
 	 * @parameter includeTableNamesRegex
 	 */
 	private String includeTableNamesRegex;
@@ -174,7 +174,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	 * followed by column name. For example: -x "(book.isbn)|(borrower.address)"
 	 * Note that each column name regular expression must be surround by ()'s
 	 * and separated from other column names by a |.
-	 * 
+	 *
 	 * @parameter excludeColumnNamesRegex
 	 */
 	private String excludeColumnNamesRegex;
@@ -183,7 +183,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	 * Allow HTML In Comments. Any HTML embedded in comments normally gets
 	 * encoded so that it's rendered as text. This option allows it to be
 	 * rendered as HTML.
-	 * 
+	 *
 	 * @parameter allowHtmlInComments
 	 */
 	private Boolean allowHtmlInComments;
@@ -191,7 +191,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	/**
 	 * Comments Initially Displayed. Column comments are normally hidden by
 	 * default. This option displays them by default.
-	 * 
+	 *
 	 * @parameter commentsInitiallyDisplayed
 	 */
 	private Boolean commentsInitiallyDisplayed;
@@ -199,7 +199,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	/**
 	 * Don't include implied foreign key relationships in the generated table
 	 * details.
-	 * 
+	 *
 	 * @parameter noImplied
 	 */
 	private Boolean noImplied;
@@ -207,7 +207,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	/**
 	 * Only generate files needed for insertion/deletion of data (e.g. for
 	 * scripts).
-	 * 
+	 *
 	 * @parameter noHtml
 	 */
 	private Boolean noHtml;
@@ -220,7 +220,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	 * java.sql.DriverManager.getConnection(...)"). Other databases (eg MySQL)
 	 * seem to only work with the first method, so don't use this parameter
 	 * unless you have to.
-	 * 
+	 *
 	 * @parameter useDriverManager
 	 */
 	private Boolean useDriverManager;
@@ -228,7 +228,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	/**
 	 * The CSS Stylesheet. Allows you to override the default SchemaSpyCSS
 	 * stylesheet.
-	 * 
+	 *
 	 * @parameter cssStylesheet
 	 */
 	private String cssStylesheet;
@@ -236,41 +236,41 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	/**
 	 * Single Sign-On. Don't require a user to be specified with -user to
 	 * simplify configuration when running in a single sign-on environment.
-	 * 
+	 *
 	 * @parameter singleSignOn
 	 */
 	private Boolean singleSignOn;
 
 	/**
-	 * Generate lower-quality diagrams. Various installations of Graphviz (depending on OS 
-	 * and/or version) will default to generating either higher or lower quality images. 
-	 * That is, some might not have the "lower quality" libraries and others might not have 
+	 * Generate lower-quality diagrams. Various installations of Graphviz (depending on OS
+	 * and/or version) will default to generating either higher or lower quality images.
+	 * That is, some might not have the "lower quality" libraries and others might not have
 	 * the "higher quality" libraries.
 	 * @parameter lowQuality
 	 */
 	private Boolean lowQuality;
 
 	/**
-	 * Generate higher-quality diagrams. Various installations of Graphviz (depending on OS 
-	 * and/or version) will default to generating either higher or lower quality images. 
-	 * That is, some might not have the "lower quality" libraries and others might not have 
+	 * Generate higher-quality diagrams. Various installations of Graphviz (depending on OS
+	 * and/or version) will default to generating either higher or lower quality images.
+	 * That is, some might not have the "lower quality" libraries and others might not have
 	 * the "higher quality" libraries.
 	 * @parameter highQuality
 	 */
 	private Boolean highQuality;
-	
+
 	/**
-	 * Evaluate all schemas in a database. Generates a high-level index of the schemas 
+	 * Evaluate all schemas in a database. Generates a high-level index of the schemas
 	 * evaluated and allows for traversal of cross-schema foreign key relationships.
 	 * Use with -schemaSpec "schemaRegularExpression" to narrow-down the schemas to include.
 	 * @parameter showAllSchemas
 	 */
 	private Boolean showAllSchemas;
-	
+
 	/**
-	 * Evaluate specified schemas. 
-	 * Similar to -showAllSchemas, but explicitly specifies which schema to evaluate without 
-	 * interrogating the database's metadata. Can be used with databases like MySQL where a 
+	 * Evaluate specified schemas.
+	 * Similar to -showAllSchemas, but explicitly specifies which schema to evaluate without
+	 * interrogating the database's metadata. Can be used with databases like MySQL where a
 	 * database isn't composed of multiple schemas.
 	 * @parameter schemas
 	 */
@@ -286,41 +286,49 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	 * @parameter noRows
 	 */
 	private Boolean noRows;
-	
+
 	/**
 	 * Don't query or display row counts.
 	 * @parameter noViews
 	 */
 	private Boolean noViews;
-	
+
 	/**
-	 * Specifies additional properties to be used when connecting to the database. 
+	 * Specifies additional properties to be used when connecting to the database.
 	 * Specify the entries directly, escaping the ='s with \= and separating each key\=value
 	 * pair with a ;.
 	 * @parameter connprops
 	 */
 	private String connprops;
-	
+
 	/**
 	 * Don't generate ads in reports
-	 * 
+	 *
 	 * @parameter noAds
 	 */
 	private Boolean noAds;
-	
+
 	/**
 	 * Don't generate sourceforge logos in reports
-	 * 
+	 *
 	 * @parameter noLogo
 	 */
 	private Boolean noLogo;
-	
+
+    /**
+     * Whether to create the report only on the execution root of a multi-module project.
+     *
+     * @parameter expression="${runOnExecutionRoot}" default-value="false"
+     * @since 5.0.4
+     */
+    protected boolean runOnExecutionRoot = false;
+
 	/**
 	 * The SchemaSpy analyser that generates the actual report.
 	 * Can be overridden for testing purposes.
 	 */
 	SchemaAnalyzer analyzer = new SchemaAnalyzer();
-	
+
 	/**
 	 * Utility class to help determine the type of the target database.
 	 */
@@ -329,10 +337,10 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	protected void setSchemaAnalyzer(SchemaAnalyzer analyzer) {
 		this.analyzer = analyzer;
 	}
-	
+
 	/**
 	 * Convenience method used to build the schemaspy command line parameters.
-	 * 
+	 *
 	 * @param argList
 	 *            the current list of schemaspy parameter options.
 	 * @param parameter
@@ -349,7 +357,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 
 	/**
 	 * Convenience method used to build the schemaspy command line parameters.
-	 * 
+	 *
 	 * @param argList
 	 *            the current list of schemaspy parameter options.
 	 * @param parameter
@@ -366,7 +374,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 
 	/**
 	 * Convenience method used to build the schemaspy command line parameters.
-	 * 
+	 *
 	 * @param argList
 	 *            the current list of schemaspy parameter options.
 	 * @param parameter
@@ -383,7 +391,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 
 	/**
 	 * Generate the Schemaspy report.
-	 * 
+	 *
 	 * @throws MavenReportException
 	 *             if schemaspy crashes
 	 * @param locale
@@ -391,6 +399,10 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	 */
 	@Override
 	protected void executeReport(Locale locale) throws MavenReportException {
+
+		if (runOnExecutionRoot && !project.isExecutionRoot()) {
+			return;
+		}
 
 		//
 		// targetDirectory should be set by the maven framework. This is
@@ -438,7 +450,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 		addFlagToArguments(argList, "-noschema", noSchema);
 		addFlagToArguments(argList, "-all", showAllSchemas);
 		addToArguments(argList, "-schemas", schemas);
-		
+
 		addToArguments(argList, "-useDriverManager", useDriverManager);
 		addToArguments(argList, "-css", cssStylesheet);
 		addFlagToArguments(argList, "-sso", singleSignOn);
@@ -500,7 +512,7 @@ public class SchemaSpyReport extends AbstractMavenReport {
 	/**
 	 * Always return true as we're using the report generated by SchemaSpy
 	 * rather than creating our own report.
-	 * 
+	 *
 	 * @return true
 	 */
 	public boolean isExternalReport() {

--- a/src/main/resources/net/sourceforge/schemaspy/dbTypes/orathin_servicename.properties
+++ b/src/main/resources/net/sourceforge/schemaspy/dbTypes/orathin_servicename.properties
@@ -1,0 +1,14 @@
+#
+# see http://schemaspy.sourceforge.net/dbtypes.html
+# for configuration / customization details
+#
+
+description=Oracle with Thin Driver
+
+# gory details in ora.properties:
+extends=ora
+
+connectionSpec=jdbc:oracle:thin:@//<host>:<port>/<db>
+host=database host
+port=port on database host
+db=database SID as known on host


### PR DESCRIPTION
Hello,
I added support for Oracle with Service Name (instead of SID) via the "orathin_servicename.properties" file.
Moreover, I added one parameter, called "runOnExecutionRoot" that runs the report only on execution root, so if you have a multi-module project, it will run only on the parent.

Thanks
Antonio Petrelli
