### PR TITLE
Correct Config.getLoadedFromJar() return value for Windows platforms

### DIFF
--- a/src/main/java/net/sourceforge/schemaspy/model/Database.java
+++ b/src/main/java/net/sourceforge/schemaspy/model/Database.java
@@ -310,7 +310,7 @@ public class Database {
         final String type;
         final String remarks;
         final String viewSql;
-        final int numRows;  // -1 if not determined
+        final long numRows;  // -1 if not determined
 
         /**
          * @param schema
@@ -320,7 +320,7 @@ public class Database {
          * @param text optional textual SQL used to create the view
          * @param numRows number of rows, or -1 if not determined
          */
-        BasicTableMeta(String schema, String name, String type, String remarks, String text, int numRows)
+        BasicTableMeta(String schema, String name, String type, String remarks, String text, long numRows)
         {
             this.schema = schema;
             this.name = name;
@@ -365,7 +365,7 @@ public class Database {
                     String remarks = getOptionalString(rs, clazz + "_comment");
                     String text = forTables ? null : getOptionalString(rs, "view_definition");
                     String rows = forTables ? getOptionalString(rs, "table_rows") : null;
-                    int numRows = rows == null ? -1 : Integer.parseInt(rows);
+                    long numRows = rows == null ? -1 : Long.parseLong(rows);
 
                     basics.add(new BasicTableMeta(sch, name, clazz, remarks, text, numRows));
                 }

--- a/src/main/java/net/sourceforge/schemaspy/model/Database.java
+++ b/src/main/java/net/sourceforge/schemaspy/model/Database.java
@@ -183,10 +183,12 @@ public class Database {
 
             // Oracle 10g introduced problematic flashback tables
             // with bizarre illegal names
-            if (name.indexOf("$") != -1) {
+            // Naming Convention "BIN$"${globalUID}${version}
+            // http://docs.oracle.com/cd/B19306_01/backup.102/b14192/flashptr004.htm#i1016977
+            if (name.indexOf("BIN$") == 0) {
                 if (fineEnabled) {
                     logger.fine("Excluding " + clazz + " " + name +
-                                ": embedded $ implies illegal name");
+                                ": \"BIN$\" prefix implies  a (deleted) table in the Oracle Recycle Bin ");
                 }
                 return false;
             }

--- a/src/main/java/net/sourceforge/schemaspy/model/Table.java
+++ b/src/main/java/net/sourceforge/schemaspy/model/Table.java
@@ -57,7 +57,7 @@ public class Table implements Comparable<Table> {
     private final CaseInsensitiveMap<TableIndex> indexes = new CaseInsensitiveMap<TableIndex>();
     private       Object id;
     private final Map<String, String> checkConstraints = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
-    private Integer numRows;
+    private Long numRows;
     protected final Database db;
     protected final Properties properties;
     private       String comments;
@@ -895,7 +895,7 @@ public class Table implements Comparable<Table> {
      *
      * @return
      */
-    public int getNumRows() {
+    public long getNumRows() {
         if (numRows == null) {
             numRows = Config.getInstance().isNumRowsEnabled() ? fetchNumRows() : -1;
         }
@@ -908,7 +908,7 @@ public class Table implements Comparable<Table> {
      *
      * @param numRows
      */
-    public void setNumRows(int numRows) {
+    public void setNumRows(long numRows) {
         this.numRows = numRows;
     }
 
@@ -918,10 +918,10 @@ public class Table implements Comparable<Table> {
      * returns -1 if unable to successfully fetch the row count
      *
      * @param db Database
-     * @return int
+     * @return long
      * @throws SQLException
      */
-    protected int fetchNumRows() {
+    protected long fetchNumRows() {
         if (properties == null) // some "meta" tables don't have associated properties
             return 0;
 
@@ -937,7 +937,7 @@ public class Table implements Comparable<Table> {
                 rs = stmt.executeQuery();
 
                 while (rs.next()) {
-                    return rs.getInt("row_count");
+                    return rs.getLong("row_count");
                 }
             } catch (SQLException sqlException) {
                 // don't die just because this failed
@@ -975,7 +975,7 @@ public class Table implements Comparable<Table> {
         }
     }
 
-    protected int fetchNumRows(String clause, boolean forceQuotes) throws SQLException {
+    protected long fetchNumRows(String clause, boolean forceQuotes) throws SQLException {
         PreparedStatement stmt = null;
         ResultSet rs = null;
         StringBuilder sql = new StringBuilder("select ");
@@ -996,7 +996,7 @@ public class Table implements Comparable<Table> {
             stmt = db.getConnection().prepareStatement(sql.toString());
             rs = stmt.executeQuery();
             while (rs.next()) {
-                return rs.getInt(1);
+                return rs.getLong(1);
             }
             return -1;
         } catch (SQLException exc) {

--- a/src/main/java/net/sourceforge/schemaspy/model/View.java
+++ b/src/main/java/net/sourceforge/schemaspy/model/View.java
@@ -68,7 +68,7 @@ public class View extends Table {
     }
 
     @Override
-    protected int fetchNumRows() {
+    protected long fetchNumRows() {
         return 0;
     }
 

--- a/src/main/java/net/sourceforge/schemaspy/util/URLEncoder.java
+++ b/src/main/java/net/sourceforge/schemaspy/util/URLEncoder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013 Wakaleo Consulting.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.sourceforge.schemaspy.util;
+
+import java.io.UnsupportedEncodingException;
+import net.sourceforge.schemaspy.Config;
+
+/**
+ * Percent-encode Strings for use in URLs.
+ *
+ * @author sturton
+ */
+public class URLEncoder {
+
+  /*
+   *  Encoding characterset 
+   */
+  private  String  charset = Config.getInstance().getCharset();
+
+  public URLEncoder(String charset) {
+    this.charset = charset ;
+  }
+
+   /**
+     * Return an URL-encoded version of the specified string in the specified encoding.
+     *
+     * <p>Any encoding failure results in the return of the original string.
+     * </p>
+     * @param str 
+     * @return 
+     */
+    public String encode(String str) {
+	try {
+    	   String url = java.net.URLEncoder.encode(str, charset);
+	   int len = url.length();
+    	   StringBuilder buf = new StringBuilder(len * 2); // x2 should limit # of reallocs
+    	   for (int i = 0; i < len; i++) {
+			buf.append( ( '+' == url.charAt(i) )
+				   ? "%20"
+				   : url.charAt(i)
+				  );
+		}
+    	   return buf.toString();
+	}
+	catch(UnsupportedEncodingException uee)
+	{
+	  return str;
+	}
+    }
+  
+}

--- a/src/main/java/net/sourceforge/schemaspy/view/DotNode.java
+++ b/src/main/java/net/sourceforge/schemaspy/view/DotNode.java
@@ -151,7 +151,7 @@ public class DotNode {
         if (table.isView())
             buf.append("view");
         else {
-            final int numRows = table.getNumRows();
+            final long numRows = table.getNumRows();
             if (displayNumRows && numRows != -1) {
                 buf.append(NumberFormat.getInstance().format(numRows));
                 buf.append(" row");

--- a/src/main/java/net/sourceforge/schemaspy/view/DotNode.java
+++ b/src/main/java/net/sourceforge/schemaspy/view/DotNode.java
@@ -26,6 +26,7 @@ import net.sourceforge.schemaspy.Config;
 import net.sourceforge.schemaspy.model.Table;
 import net.sourceforge.schemaspy.model.TableColumn;
 import net.sourceforge.schemaspy.model.TableIndex;
+import net.sourceforge.schemaspy.util.URLEncoder;
 
 public class DotNode {
     private final Table table;
@@ -34,6 +35,7 @@ public class DotNode {
     private final Set<TableColumn> excludedColumns = new HashSet<TableColumn>();
     private final String lineSeparator = System.getProperty("line.separator");
     private final boolean displayNumRows = Config.getInstance().isNumRowsEnabled();
+    private static final URLEncoder urlEncoder = new URLEncoder(Config.DOT_CHARSET);
 
     /**
      * Create a DotNode that is a focal point of a diagram.
@@ -170,7 +172,7 @@ public class DotNode {
 
         buf.append("    </TABLE>>" + lineSeparator);
         if (!table.isRemote() || Config.getInstance().isOneOfMultipleSchemas())
-            buf.append("    URL=\"" + path + toNCR(tableName) + ".html\"" + lineSeparator);
+            buf.append("    URL=\"" + path + toNCR( urlEncoder.encode(tableName) ) + ".html\"" + lineSeparator);
         buf.append("    tooltip=\"" + toNCR(fqTableName) + "\"" + lineSeparator);
         buf.append("  ];");
 

--- a/src/main/java/net/sourceforge/schemaspy/view/HtmlAnomaliesPage.java
+++ b/src/main/java/net/sourceforge/schemaspy/view/HtmlAnomaliesPage.java
@@ -28,6 +28,7 @@ import net.sourceforge.schemaspy.model.Database;
 import net.sourceforge.schemaspy.model.ForeignKeyConstraint;
 import net.sourceforge.schemaspy.model.Table;
 import net.sourceforge.schemaspy.model.TableColumn;
+import net.sourceforge.schemaspy.util.HtmlEncoder;
 import net.sourceforge.schemaspy.util.LineWriter;
 
 /**
@@ -110,7 +111,7 @@ public class HtmlAnomaliesPage extends HtmlFormatter {
                     out.write("  <td class='detail'>");
                     String tableName = childTable.getName();
                     out.write("<a href='tables/");
-                    out.write(tableName);
+                    out.write(encodeHref(tableName));
                     out.write(".html'>");
                     out.write(tableName);
                     out.write("</a>.");
@@ -120,7 +121,7 @@ public class HtmlAnomaliesPage extends HtmlFormatter {
                     out.write("  <td class='detail'>");
                     tableName = impliedConstraint.getParentTable().getName();
                     out.write("<a href='tables/");
-                    out.write(tableName);
+                    out.write(encodeHref(tableName));
                     out.write(".html'>");
                     out.write(tableName);
                     out.write("</a>.");
@@ -167,7 +168,7 @@ public class HtmlAnomaliesPage extends HtmlFormatter {
                 out.writeln(" <tr>");
                 out.write("  <td class='detail'>");
                 out.write("<a href='tables/");
-                out.write(table.getName());
+                out.write(encodeHref(table.getName()));
                 out.write(".html'>");
                 out.write(table.getName());
                 out.write("</a>");
@@ -204,7 +205,7 @@ public class HtmlAnomaliesPage extends HtmlFormatter {
                 out.writeln(" <tr>");
                 out.write("  <td class='detail'>");
                 out.write("<a href='tables/");
-                out.write(table.getName());
+                out.write(encodeHref(table.getName()));
                 out.write(".html'>");
                 out.write(table.getName());
                 out.write("</a>");
@@ -238,7 +239,7 @@ public class HtmlAnomaliesPage extends HtmlFormatter {
                 out.writeln(" <tr>");
                 out.write("  <td class='detail'>");
                 out.write("<a href='tables/");
-                out.write(table.getName());
+                out.write(encodeHref(table.getName()));
                 out.write(".html'>");
                 out.write(table.getName());
                 out.write("</a></td><td class='detail'>");
@@ -275,7 +276,7 @@ public class HtmlAnomaliesPage extends HtmlFormatter {
                 out.write("  <td class='detail'>");
                 String tableName = column.getTable().getName();
                 out.write("<a href='tables/");
-                out.write(tableName);
+                out.write(encodeHref(tableName));
                 out.write(".html'>");
                 out.write(tableName);
                 out.write("</a>.");

--- a/src/main/java/net/sourceforge/schemaspy/view/HtmlColumnsPage.java
+++ b/src/main/java/net/sourceforge/schemaspy/view/HtmlColumnsPage.java
@@ -227,7 +227,7 @@ public class HtmlColumnsPage extends HtmlFormatter {
             } else {
                 buf.append(" class='notSortedByColumn'>");
                 buf.append("<a href='");
-                buf.append(selectedColumn.getLocation(columnName));
+                buf.append(encodeHref(selectedColumn.getLocation(columnName)));
                 buf.append("#columns'><span class='notSortedByColumn'>");
                 buf.append(columnName);
                 buf.append("</span></a>");

--- a/src/main/java/net/sourceforge/schemaspy/view/HtmlConstraintsPage.java
+++ b/src/main/java/net/sourceforge/schemaspy/view/HtmlConstraintsPage.java
@@ -146,7 +146,7 @@ public class HtmlConstraintsPage extends HtmlFormatter {
         for (Iterator<TableColumn> iter = constraint.getChildColumns().iterator(); iter.hasNext(); ) {
             TableColumn column = iter.next();
             html.write("<a href='tables/");
-            html.write(column.getTable().getName());
+            html.write(encodeHref(column.getTable().getName()));
             html.write(".html'>");
             html.write(column.getTable().getName());
             html.write("</a>");
@@ -160,7 +160,7 @@ public class HtmlConstraintsPage extends HtmlFormatter {
         for (Iterator<TableColumn> iter = constraint.getParentColumns().iterator(); iter.hasNext(); ) {
             TableColumn column = iter.next();
             html.write("<a href='tables/");
-            html.write(column.getTable().getName());
+            html.write(encodeHref(column.getTable().getName()));
             html.write(".html'>");
             html.write(column.getTable().getName());
             html.write("</a>");
@@ -234,7 +234,7 @@ public class HtmlConstraintsPage extends HtmlFormatter {
         for (String name : constraints.keySet()) {
             html.writeln(" <tr>");
             html.write("  <td class='detail' valign='top'><a href='tables/");
-            html.write(table.getName());
+            html.write(encodeHref(table.getName()));
             html.write(".html'>");
             html.write(table.getName());
             html.write("</a></td>");

--- a/src/main/java/net/sourceforge/schemaspy/view/HtmlFormatter.java
+++ b/src/main/java/net/sourceforge/schemaspy/view/HtmlFormatter.java
@@ -19,8 +19,6 @@
 package net.sourceforge.schemaspy.view;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -32,12 +30,13 @@ import net.sourceforge.schemaspy.model.TableColumn;
 import net.sourceforge.schemaspy.util.Dot;
 import net.sourceforge.schemaspy.util.HtmlEncoder;
 import net.sourceforge.schemaspy.util.LineWriter;
+import net.sourceforge.schemaspy.util.URLEncoder;
 
 public class HtmlFormatter {
     protected final boolean encodeComments       = Config.getInstance().isEncodeCommentsEnabled();
     protected final boolean displayNumRows       = Config.getInstance().isNumRowsEnabled();
     private   final boolean isMetered            = Config.getInstance().isMeterEnabled();
-    private   final String  charset              = Config.getInstance().getCharset();
+    private   final URLEncoder  urlEncoder       = new URLEncoder( Config.getInstance().getCharset());
 
     protected HtmlFormatter() {
     }
@@ -291,32 +290,14 @@ public class HtmlFormatter {
     }
 
 
-    /**
-     * Return an URL-encoded version of the specified string in the specified encoding.
+    /*
+     * Return an URL-encoded version of the specified string.
      *
      * @param str
-     * @param charset
      * @return
      */
     protected String encodeHref(String str) {
-	try {
-    	   //return URLEncoder.encode(str, charset).replaceAll("+","%20");
-    	   String url = URLEncoder.encode(str, charset);
-	   int len = url.length();
-    	   StringBuilder buf = new StringBuilder(len * 2); // x2 should limit # of reallocs
-    	   for (int i = 0; i < len; i++) {
-			buf.append( ( '+' == url.charAt(i) )
-				   ? "%20"
-				   : url.charAt(i)
-				  );
-		}
-    	   return buf.toString();
-	}
-	catch(UnsupportedEncodingException uee)
-	//catch(Exception ex)
-	{
-	  return str;
-	}
+    	   return urlEncoder.encode(str);
     }
 
 

--- a/src/main/java/net/sourceforge/schemaspy/view/HtmlFormatter.java
+++ b/src/main/java/net/sourceforge/schemaspy/view/HtmlFormatter.java
@@ -128,7 +128,7 @@ public class HtmlFormatter {
             html.writeln("  <li" + (isOrphansPage() ? " id='current'" : "") + "><a href='" + path + "utilities.html' title='View of tables with neither parents nor children'>Utility&nbsp;Tables</a></li>");
         html.writeln("  <li" + (isConstraintsPage() ? " id='current'" : "") + "><a href='" + path + "constraints.html' title='Useful for diagnosing error messages that just give constraint name or number'>Constraints</a></li>");
         html.writeln("  <li" + (isAnomaliesPage() ? " id='current'" : "") + "><a href='" + path + "anomalies.html' title=\"Things that might not be quite right\">Anomalies</a></li>");
-        html.writeln("  <li" + (isColumnsPage() ? " id='current'" : "") + "><a href='" + path + encodeHref(HtmlColumnsPage.getInstance().getColumnInfos().get(0)) + "' title=\"All of the columns in the schema\">Columns</a></li>");
+        html.writeln("  <li" + (isColumnsPage() ? " id='current'" : "") + "><a href='" + path + encodeHref(HtmlColumnsPage.getInstance().getColumnInfos().get(0).toString()) + "' title=\"All of the columns in the schema\">Columns</a></li>");
         html.writeln("  <li><a href='http://sourceforge.net/donate/index.php?group_id=137197' title='Please help keep SchemaSpy alive' target='_blank'>Donate</a></li>");
         html.writeln(" </ul>");
         html.writeln("</div>");

--- a/src/main/java/net/sourceforge/schemaspy/view/HtmlFormatter.java
+++ b/src/main/java/net/sourceforge/schemaspy/view/HtmlFormatter.java
@@ -19,6 +19,8 @@
 package net.sourceforge.schemaspy.view;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -35,6 +37,7 @@ public class HtmlFormatter {
     protected final boolean encodeComments       = Config.getInstance().isEncodeCommentsEnabled();
     protected final boolean displayNumRows       = Config.getInstance().isNumRowsEnabled();
     private   final boolean isMetered            = Config.getInstance().isMeterEnabled();
+    private   final String  charset              = Config.getInstance().getCharset();
 
     protected HtmlFormatter() {
     }
@@ -125,7 +128,7 @@ public class HtmlFormatter {
             html.writeln("  <li" + (isOrphansPage() ? " id='current'" : "") + "><a href='" + path + "utilities.html' title='View of tables with neither parents nor children'>Utility&nbsp;Tables</a></li>");
         html.writeln("  <li" + (isConstraintsPage() ? " id='current'" : "") + "><a href='" + path + "constraints.html' title='Useful for diagnosing error messages that just give constraint name or number'>Constraints</a></li>");
         html.writeln("  <li" + (isAnomaliesPage() ? " id='current'" : "") + "><a href='" + path + "anomalies.html' title=\"Things that might not be quite right\">Anomalies</a></li>");
-        html.writeln("  <li" + (isColumnsPage() ? " id='current'" : "") + "><a href='" + path + HtmlColumnsPage.getInstance().getColumnInfos().get(0) + "' title=\"All of the columns in the schema\">Columns</a></li>");
+        html.writeln("  <li" + (isColumnsPage() ? " id='current'" : "") + "><a href='" + path + encodeHref(HtmlColumnsPage.getInstance().getColumnInfos().get(0)) + "' title=\"All of the columns in the schema\">Columns</a></li>");
         html.writeln("  <li><a href='http://sourceforge.net/donate/index.php?group_id=137197' title='Please help keep SchemaSpy alive' target='_blank'>Donate</a></li>");
         html.writeln(" </ul>");
         html.writeln("</div>");
@@ -252,7 +255,7 @@ public class HtmlFormatter {
             for (TableColumn column : notInDiagram) {
                 if (!column.getTable().equals(table)) {
                     html.write("<a href=\"" + getPathToRoot() + "tables/");
-                    html.write(column.getTable().getName());
+                    html.write(encodeHref(column.getTable().getName()));
                     html.write(".html\">");
                     html.write(column.getTable().getName());
                     html.write(".");
@@ -286,6 +289,36 @@ public class HtmlFormatter {
         html.writeln("</body>");
         html.writeln("</html>");
     }
+
+
+    /**
+     * Return an URL-encoded version of the specified string in the specified encoding.
+     *
+     * @param str
+     * @param charset
+     * @return
+     */
+    protected String encodeHref(String str) {
+	try {
+    	   //return URLEncoder.encode(str, charset).replaceAll("+","%20");
+    	   String url = URLEncoder.encode(str, charset);
+	   int len = url.length();
+    	   StringBuilder buf = new StringBuilder(len * 2); // x2 should limit # of reallocs
+    	   for (int i = 0; i < len; i++) {
+			buf.append( ( '+' == url.charAt(i) )
+				   ? "%20"
+				   : url.charAt(i)
+				  );
+		}
+    	   return buf.toString();
+	}
+	catch(UnsupportedEncodingException uee)
+	//catch(Exception ex)
+	{
+	  return str;
+	}
+    }
+
 
     /**
      * Override if your output doesn't live in the root directory.

--- a/src/main/java/net/sourceforge/schemaspy/view/HtmlMainIndexPage.java
+++ b/src/main/java/net/sourceforge/schemaspy/view/HtmlMainIndexPage.java
@@ -193,7 +193,7 @@ public class HtmlMainIndexPage extends HtmlFormatter {
     private void writeLineItem(Table table, boolean showIds, LineWriter html) throws IOException {
         html.write(" <tr class='" + (table.isView() ? "view" : "tbl") + "' valign='top'>");
         html.write("  <td class='detail'><a href='tables/");
-        html.write(table.getName());
+        html.write(encodeHref(table.getName()));
         html.write(".html'>");
         html.write(table.getName());
         html.writeln("</a></td>");

--- a/src/main/java/net/sourceforge/schemaspy/view/HtmlMainIndexPage.java
+++ b/src/main/java/net/sourceforge/schemaspy/view/HtmlMainIndexPage.java
@@ -79,7 +79,7 @@ public class HtmlMainIndexPage extends HtmlFormatter {
 
         int numTableCols = 0;
         int numViewCols = 0;
-        int numRows = 0;
+        long numRows = 0;
         for (Table table : byName) {
             writeLineItem(table, showIds, html);
 
@@ -244,7 +244,7 @@ public class HtmlMainIndexPage extends HtmlFormatter {
         html.writeln("  </tr>");
     }
 
-    protected void writeFooter(int numTables, int numTableCols, int numViews, int numViewCols, int numRows, LineWriter html) throws IOException {
+    protected void writeFooter(int numTables, int numTableCols, int numViews, int numViewCols, long numRows, LineWriter html) throws IOException {
         html.writeln("  <tr>");
         html.writeln("    <td class='detail'>&nbsp;</td>");
         html.writeln("    <td class='detail'>&nbsp;</td>");

--- a/src/main/java/net/sourceforge/schemaspy/view/HtmlMultipleSchemasIndexPage.java
+++ b/src/main/java/net/sourceforge/schemaspy/view/HtmlMultipleSchemasIndexPage.java
@@ -73,7 +73,7 @@ public class HtmlMultipleSchemasIndexPage extends HtmlFormatter {
         }
         html.writeln("</title>");
         html.write("  <link rel=stylesheet href='");
-        html.write(aSchema);
+        html.write(encodeHref(aSchema));
         html.writeln("/schemaSpy.css' type='text/css'>");
         html.writeln("  <meta HTTP-EQUIV='Content-Type' CONTENT='text/html; charset=" + Config.getInstance().getCharset() + "'>");
         html.writeln("</head>");
@@ -141,7 +141,7 @@ public class HtmlMultipleSchemasIndexPage extends HtmlFormatter {
     private void writeLineItem(String schema, LineWriter index) throws IOException {
         index.writeln(" <tr>");
         index.write("  <td class='detail'><a href='");
-        index.write(schema);
+        index.write(encodeHref(schema));
         index.write("/index.html'>");
         index.write(schema);
         index.writeln("</a></td>");

--- a/src/main/java/net/sourceforge/schemaspy/view/HtmlOrphansPage.java
+++ b/src/main/java/net/sourceforge/schemaspy/view/HtmlOrphansPage.java
@@ -87,7 +87,7 @@ public class HtmlOrphansPage extends HtmlDiagramFormatter {
                     return false;
                 }
 
-                html.write("  <img src='diagrams/summary/" + imgFile.getName() + "' usemap='#" + table + "' border='0' alt='' align='top'");
+                html.write("  <img src='diagrams/summary/" + encodeHref( imgFile.getName() ) + "' usemap='#" + table + "' border='0' alt='' align='top'");
                 if (orphansWithImpliedRelationships.contains(table))
                     html.write(" class='impliedNotOrphan'");
                 html.writeln(">");

--- a/src/main/java/net/sourceforge/schemaspy/view/HtmlRelationshipsPage.java
+++ b/src/main/java/net/sourceforge/schemaspy/view/HtmlRelationshipsPage.java
@@ -81,7 +81,7 @@ public class HtmlRelationshipsPage extends HtmlDiagramFormatter {
                     System.out.print(".");
 
                 html.writeln(dot.generateDiagram(compactRelationshipsDotFile, compactRelationshipsDiagramFile));
-                html.writeln("  <a name='diagram'><img id='realCompactImg' src='diagrams/summary/" + compactRelationshipsDiagramFile.getName() + "' usemap='#compactRelationshipsDiagram' class='diagram' border='0' alt=''></a>");
+                html.writeln("  <a name='diagram'><img id='realCompactImg' src='diagrams/summary/" + encodeHref( compactRelationshipsDiagramFile.getName() ) + "' usemap='#compactRelationshipsDiagram' class='diagram' border='0' alt=''></a>");
 
                 // we've run into instances where the first diagrams get generated, but then
                 // dot fails on the second one...try to recover from that scenario 'somewhat'
@@ -91,7 +91,7 @@ public class HtmlRelationshipsPage extends HtmlDiagramFormatter {
                         System.out.print(".");
 
                     html.writeln(dot.generateDiagram(largeRelationshipsDotFile, largeRelationshipsDiagramFile));
-                    html.writeln("  <a name='diagram'><img id='realLargeImg' src='diagrams/summary/" + largeRelationshipsDiagramFile.getName() + "' usemap='#largeRelationshipsDiagram' class='diagram' border='0' alt=''></a>");
+                    html.writeln("  <a name='diagram'><img id='realLargeImg' src='diagrams/summary/" + encodeHref( largeRelationshipsDiagramFile.getName() ) + "' usemap='#largeRelationshipsDiagram' class='diagram' border='0' alt=''></a>");
                 } catch (Dot.DotFailure dotFailure) {
                     System.err.println("dot failed to generate all of the relationships diagrams:");
                     System.err.println(dotFailure);
@@ -105,13 +105,13 @@ public class HtmlRelationshipsPage extends HtmlDiagramFormatter {
                         System.out.print(".");
 
                     html.writeln(dot.generateDiagram(compactImpliedDotFile, compactImpliedDiagramFile));
-                    html.writeln("  <a name='diagram'><img id='impliedCompactImg' src='diagrams/summary/" + compactImpliedDiagramFile.getName() + "' usemap='#compactImpliedRelationshipsDiagram' class='diagram' border='0' alt=''></a>");
+                    html.writeln("  <a name='diagram'><img id='impliedCompactImg' src='diagrams/summary/" + encodeHref(compactImpliedDiagramFile.getName()) + "' usemap='#compactImpliedRelationshipsDiagram' class='diagram' border='0' alt=''></a>");
 
                     if (!fineEnabled)
                         System.out.print(".");
 
                     html.writeln(dot.generateDiagram(largeImpliedDotFile, largeImpliedDiagramFile));
-                    html.writeln("  <a name='diagram'><img id='impliedLargeImg' src='diagrams/summary/" + largeImpliedDiagramFile.getName() + "' usemap='#largeImpliedRelationshipsDiagram' class='diagram' border='0' alt=''></a>");
+                    html.writeln("  <a name='diagram'><img id='impliedLargeImg' src='diagrams/summary/" + encodeHref(largeImpliedDiagramFile.getName() ) + "' usemap='#largeImpliedRelationshipsDiagram' class='diagram' border='0' alt=''></a>");
                 }
             } catch (Dot.DotFailure dotFailure) {
                 System.err.println("dot failed to generate all of the relationships diagrams:");

--- a/src/main/java/net/sourceforge/schemaspy/view/HtmlTableDiagrammer.java
+++ b/src/main/java/net/sourceforge/schemaspy/view/HtmlTableDiagrammer.java
@@ -61,18 +61,18 @@ public class HtmlTableDiagrammer extends HtmlDiagramFormatter {
             }
             html.write(map);
             map = null;
-            html.writeln("  <a name='diagram'><img id='oneDegreeImg' src='../diagrams/" + oneDegreeDiagramFile.getName() + "' usemap='#oneDegreeRelationshipsDiagram' class='diagram' border='0' alt='' align='left'></a>");
+            html.writeln("  <a name='diagram'><img id='oneDegreeImg' src='../diagrams/" + encodeHref( oneDegreeDiagramFile.getName() ) + "' usemap='#oneDegreeRelationshipsDiagram' class='diagram' border='0' alt='' align='left'></a>");
 
             if (impliedDotFile.exists()) {
                 html.writeln(dot.generateDiagram(impliedDotFile, impliedDiagramFile));
-                html.writeln("  <a name='diagram'><img id='impliedTwoDegreesImg' src='../diagrams/" + impliedDiagramFile.getName() + "' usemap='#impliedTwoDegreesRelationshipsDiagram' class='diagram' border='0' alt='' align='left'></a>");
+                html.writeln("  <a name='diagram'><img id='impliedTwoDegreesImg' src='../diagrams/" + encodeHref( impliedDiagramFile.getName() ) + "' usemap='#impliedTwoDegreesRelationshipsDiagram' class='diagram' border='0' alt='' align='left'></a>");
             } else {
                 impliedDotFile.delete();
                 impliedDiagramFile.delete();
             }
             if (twoDegreesDotFile.exists()) {
                 html.writeln(dot.generateDiagram(twoDegreesDotFile, twoDegreesDiagramFile));
-                html.writeln("  <a name='diagram'><img id='twoDegreesImg' src='../diagrams/" + twoDegreesDiagramFile.getName() + "' usemap='#twoDegreesRelationshipsDiagram' class='diagram' border='0' alt='' align='left'></a>");
+                html.writeln("  <a name='diagram'><img id='twoDegreesImg' src='../diagrams/" + encodeHref (twoDegreesDiagramFile.getName() ) + "' usemap='#twoDegreesRelationshipsDiagram' class='diagram' border='0' alt='' align='left'></a>");
             } else {
                 twoDegreesDotFile.delete();
                 twoDegreesDiagramFile.delete();

--- a/src/main/java/net/sourceforge/schemaspy/view/HtmlTablePage.java
+++ b/src/main/java/net/sourceforge/schemaspy/view/HtmlTablePage.java
@@ -150,7 +150,7 @@ public class HtmlTablePage extends HtmlFormatter {
         }
         if (tableName != null) {
             out.write(" <td class='detail'><a href='tables/");
-            out.write(tableName);
+            out.write(encodeHref(tableName));
             out.write(".html'>");
             out.write(tableName);
             out.writeln("</a></td>");
@@ -256,7 +256,7 @@ public class HtmlTablePage extends HtmlFormatter {
                 if (column.getTable().isRemote()) {
                     out.write("../../" + column.getTable().getSchema() + "/tables/");
                 }
-                out.write(columnTableName);
+                out.write(encodeHref(columnTableName));
                 out.write(".html");
             }
             out.write("'>");
@@ -434,7 +434,7 @@ public class HtmlTablePage extends HtmlFormatter {
                 out.write("  ");
                 for (Table t : references) {
                     out.write("<a href='");
-                    out.write(t.getName());
+                    out.write(encodeHref(t.getName()));
                     out.write(".html'>");
                     out.write(t.getName());
                     out.write("</a>&nbsp;");

--- a/src/main/resources/net/sourceforge/schemaspy/dbTypes/ora.properties
+++ b/src/main/resources/net/sourceforge/schemaspy/dbTypes/ora.properties
@@ -39,7 +39,7 @@ selectColumnCommentsSql=select table_name, column_name, comments from all_col_co
 # return row_count for a specific :table
 #  many times faster than select count(*)
 #  thanks to Mikheil Kapanadze for the SQL
-selectRowCountSql=select table_rows row_count from information_schema.tables where table_name=:table 
+selectRowCountSql=select num_rows row_count from all_tables where table_name=:table and owner = :owner 
 
 # regular expression used in conjunction with -all (and can be command line param '-schemaSpec')
 # this says which schemas to include in our evaluation of "all schemas"

--- a/src/main/resources/net/sourceforge/schemaspy/dbTypes/oradba.properties
+++ b/src/main/resources/net/sourceforge/schemaspy/dbTypes/oradba.properties
@@ -1,0 +1,60 @@
+#
+# see http://schemaspy.sourceforge.net/dbtypes.html
+# for configuration / customization details
+#
+
+description=Oracle with OCI8 Driver and access to DBA_* catalogue views 
+
+connectionSpec=jdbc:oracle:oci8:@<db>
+db=database name (from TNSNAMES.ORA)
+
+driver=oracle.jdbc.driver.OracleDriver
+
+# Sample path to the oracle drivers.
+# Use -dp to override.
+driverPath=c:/Oracle8I/ora81/jdbc/lib/classes12.zip
+
+# this Oracle driver's metadata services aren't thread safe so limit its access to one thread
+dbThreads=1
+
+# return table_schema, table_name, table_comment, table_rows 
+#   for a specific :schema 
+#
+# querying table_rows in this manner is significantly faster than the "select count(*)"
+#   implementation, but will be an estimate based on datrabase statistics 
+# have table_rows evaluate to null if an approximation isn't appropriate for your situation
+selectTablesSql=select t.owner as table_schema, t.table_name, tc.comments AS table_comment, t.num_rows as table_rows from dba_tables t JOIN dba_tab_comments tc ON (t.owner = tc.owner and t.table_name = tc.table_name) where t.owner=:schema
+
+# return view_schema, view_name, view_definition, view_comment
+#   for a specific :schema 
+selectViewsSql=select v.owner as view_schema, v.view_name as view_name, v.text AS view_definition, vc.comments as view_comment from dba_views v JOIN dba_tab_comments vc ON (v.owner = vc.owner and v.view_name = vc.table_name) where v.owner=:schema
+
+# return text that represents a specific :view / :schema
+selectViewSql=select text from dba_views where view_name=:view and owner=:owner
+
+# return table_name, constraint_name and text for a specific :schema
+selectCheckConstraintsSql=select table_name, constraint_name, search_condition text from dba_constraints where constraint_type = 'C' and constraint_name not like 'SYS%' and owner = :owner
+
+# Oracle's driver does 'inappropriate things' when you call DatabaseMetaData.getIndexInfo().
+# (Oracle Bug No. 2686037 - IMPROVE IMPLEMENTATION OF DATABASEMETADATA.GETINDEXINFO - per Andrea (bsq99)
+# This is an opportunity to bypass that 'badness'
+selectIndexesSql=select null as table_cat, owner as table_schem, table_name, 0 as NON_UNIQUE, null as index_qualifier, null as index_name, 0 as type, 0 as ordinal_position, null as column_name, null as asc_or_desc, num_rows as cardinality, blocks as pages, null as filter_condition from dba_tables where table_name = :table and owner = :owner union select null as table_cat, i.owner as table_schem, i.table_name, decode (i.uniqueness, 'UNIQUE', 0, 1), null as index_qualifier, i.index_name, 1 as type, c.column_position as ordinal_position, c.column_name, null as asc_or_desc, i.distinct_keys as cardinality, i.leaf_blocks as pages, null as filter_condition from dba_indexes i, dba_ind_columns c where i.table_name = :table and i.owner = :owner and i.index_name = c.index_name and i.table_owner = c.table_owner and i.table_name = c.table_name and i.owner = c.index_owner
+
+# return table_name, comments for a specific :schema
+# useful if db driver doesn't return this info
+selectTableCommentsSql=select table_name, comments from dba_tab_comments where owner=:owner
+
+# return table_name, column_name, comments for a specific :schema
+# useful if db driver doesn't return this info
+selectColumnCommentsSql=select table_name, column_name, comments from dba_col_comments where owner=:owner
+
+# return row_count for a specific :table
+#  many times faster than select count(*)
+#  thanks to Mikheil Kapanadze for the SQL
+selectRowCountSql=select num_rows row_count from dba_tables where table_name=:table and owner = :owner
+
+
+# regular expression used in conjunction with -all (and can be command line param '-schemaSpec')
+# this says which schemas to include in our evaluation of "all schemas"
+# basically .* (at the end) matches anything and the rest of it says "except SYS or SYSTEM or ......."
+schemaSpec=(?!^SYS$|^SYSTEM$|^DBSNMP$|^OUTLN$|^MDSYS$|^ORDSYS$|^ORDPLUGINS$|^CTXSYS$|^DSSYS$|^PERFSTAT$|^WKPROXY$|^WKSYS$|^WMSYS$|^XDB$|^ANONYMOUS$|^ODM$|^ODM_MTR$|^OLAPSYS$|^TRACESVR$|^REPADMIN$).*

--- a/src/main/resources/net/sourceforge/schemaspy/dbTypes/oradbathin.properties
+++ b/src/main/resources/net/sourceforge/schemaspy/dbTypes/oradbathin.properties
@@ -1,0 +1,14 @@
+#
+# see http://schemaspy.sourceforge.net/dbtypes.html
+# for configuration / customization details
+#
+
+description=Oracle with Thin Driver and access to DBA_* catalogue views 
+
+# gory details in ora.properties:
+extends=oradba
+
+connectionSpec=jdbc:oracle:thin:@<host>:<port>:<db>
+host=database host
+port=port on database host
+db=database SID as known on host

--- a/src/main/resources/net/sourceforge/schemaspy/dbTypes/oradbathin_servicename.properties
+++ b/src/main/resources/net/sourceforge/schemaspy/dbTypes/oradbathin_servicename.properties
@@ -1,0 +1,14 @@
+#
+# see http://schemaspy.sourceforge.net/dbtypes.html
+# for configuration / customization details
+#
+
+description=Oracle with Thin Driver and access to DBA_* catalogue views 
+
+# gory details in ora.properties:
+extends=oradba
+
+connectionSpec=jdbc:oracle:thin:@//<host>:<port>/<db>
+host=database host
+port=port on database host
+db=database SID as known on host

--- a/src/main/resources/net/sourceforge/schemaspy/dbTypes/timesten.properties
+++ b/src/main/resources/net/sourceforge/schemaspy/dbTypes/timesten.properties
@@ -1,0 +1,20 @@
+#
+# see http://schemaspy.sourceforge.net/dbtypes.html
+# for configuration / customization details
+#
+
+description=TimesTen Direct
+
+connectionSpec=jdbc:timesten:direct:<db>
+db=ODBC DSN
+
+driver=com.timesten.jdbc.TimesTenDriver
+
+# Sample path to the timesten drivers.
+# Use -dp to override.
+driverPath=${TT_HOME}/lib/ttjdbc6.jar
+
+# return text that represents a specific :view / :schema
+selectViewSql=select text view_definition from all_views where view_name=:view and owner=:owner
+
+#Cannot get View Column information (See Oracle Support document - Unable To Retrieve Column Information From Views using SQLColumns [ID 1323027.1] )

--- a/src/main/resources/net/sourceforge/schemaspy/dbTypes/timestencs.properties
+++ b/src/main/resources/net/sourceforge/schemaspy/dbTypes/timestencs.properties
@@ -1,0 +1,19 @@
+#
+# see http://schemaspy.sourceforge.net/dbtypes.html
+# for configuration / customization details
+#
+
+extends=timesten
+
+description=TimesTen via client 
+
+connectionSpec=jdbc:timesten:client:TTC_SERVER=<host>;TCP_PORT=<port>;TTC_SERVER_DSN=<db>
+host=TTC_SERVER (logical remote server)
+port=port
+db=TTC_SERVER_DSN (DSN on logical remote server)
+
+#driver=com.timesten.jdbc.TimesTenDriver
+
+# Sample path to the timesten drivers.
+# Use -dp to override.
+#driverPath=${TT_HOME}/lib/ttjdbc6.jar


### PR DESCRIPTION
Correct Config.getLoadedFromJar() return value for Windows platforms canonical path, falling back to the original value if is not valid.

The original correction prefixed the JAR path name with a spurious "/".  This code returns the correct value for  Windows platforms.  

Allow tables to contain dollar signs.
[
SchemaSpy core attempts to eliminate Oracle tables in the Recycle Bin (prefixed with "BIN$") - the filter was originally to eliminate all tables with names containing a dollar $ character.
]

Allow columns to contain URL special characters (such as hash signs). 
Links to target containing URL special character were not being URL-encoded.  

