### PR TITLE
Provide `schemaspy:help` goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,22 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.2</version>
+        <configuration>
+          <goalPrefix>schemaspy</goalPrefix>
+        </configuration>
+        <executions>
+          <execution>
+            <id>generated-helpmojo</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
     <extensions>
       <extension>


### PR DESCRIPTION
This pull request adds configuration to auto-generate a `help` goal.

As a user I find it helpful if a plugin provides a `help` goal, so that I can invoke `schemaspy:help` in the shell and get a list of available goals and usage description. Such a goal can be auto-generated at build time using the [maven-plugin-plugin](http://maven.apache.org/plugin-tools/maven-plugin-plugin/).

Example:
`mvn com.wakaleo.schemaspy:maven-schemaspy-plugin:help`

    This plugin has 2 goals:

    schemaspy:help
      Display help information on maven-schemaspy-plugin.
      Call mvn schemaspy:help -Ddetail=true -Dgoal=<goal-name> to display parameter
      details.

    schemaspy:schemaspy
      The SchemaSpy Maven plugin report.

`mvn com.wakaleo.schemaspy:maven-schemaspy-plugin:help -Ddetail=true -Dschemaspy`

    schemaspy:schemaspy
      The SchemaSpy Maven plugin report.

      Available parameters:

        allowHtmlInComments
          Allow HTML In Comments. Any HTML embedded in comments normally gets
          encoded so that it's rendered as text. This option allows it to be
          rendered as HTML.

        commentsInitiallyDisplayed
          Comments Initially Displayed. Column comments are normally hidden by
          default. This option displays them by default.

        connprops
          Specifies additional properties to be used when connecting to the
          database. Specify the entries directly, escaping the ='s with \= and
          separating each key\=value pair with a ;. May also be a file name, useful
          for hiding connection properties from public logs.
[...]