### PR TITLE
rename artifactId (maven-schemaspy-plugin -> schemaspy-maven-plugin)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
-        <version>6</version>
+        <version>9</version>
     </parent>
     <groupId>com.wakaleo.schemaspy</groupId>
-    <artifactId>maven-schemaspy-plugin</artifactId>
+    <artifactId>schemaspy-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
     <version>5.0.4-SNAPSHOT</version>
     <inceptionYear>2007</inceptionYear>
-    <name>Maven SchemaSpy Plugin</name>
+    <name>SchemaSpy Maven Plugin</name>
     <url>https://github.com/wakaleo/maven-schemaspy-plugin</url>
     <description>
         A Maven plugin designed to generate reports using the SchemaSpy command-line tool.
@@ -175,6 +175,10 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
+                <configuration>
+                    <source>${project.build.sourceVersion}</source>
+                    <target>${project.build.targetVersion}</target>
+                </configuration>
             </plugin>
             <!-- Define the Main class of the output JAR file -->
             <plugin>
@@ -229,7 +233,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.21.0</version>
             </plugin>
-
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
@@ -254,7 +257,7 @@
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
                 <artifactId>wagon-ftp</artifactId>
-                <version>1.0-beta-6</version>
+                <version>3.0.0</version>
             </extension>
         </extensions>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>
-            <version>10.14.1.0</version>
+            <version>10.12.1.1</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/src/test/projects/unit/full-test-plugin-config.xml
+++ b/src/test/projects/unit/full-test-plugin-config.xml
@@ -31,8 +31,8 @@ under the License.
     <plugins>
         <plugin>
             <groupId>com.wakaleo.maven.plugin.schemaspy</groupId>
-            <artifactId>maven-schemaspy-plugin</artifactId>
-            <version>1.0</version>
+            <artifactId>schemaspy-maven-plugin</artifactId>
+            <version>@project.version@</version>
             <configuration>
               <databaseType>derby</databaseType>
               <database>testdb</database>

--- a/src/test/projects/unit/jdbcurl-test-plugin-config.xml
+++ b/src/test/projects/unit/jdbcurl-test-plugin-config.xml
@@ -31,8 +31,8 @@ under the License.
     <plugins>
         <plugin>
             <groupId>com.wakaleo.schemaspy</groupId>
-            <artifactId>maven-schemaspy-plugin</artifactId>
-            <version>1.0</version>
+            <artifactId>schemaspy-maven-plugin</artifactId>
+            <version>@project.version@</version>
             <configuration>
               <outputDirectory>target/reports/jdbcurl-test</outputDirectory>
               <database>testdb</database>     

--- a/src/test/projects/unit/mysql-plugin-config.xml
+++ b/src/test/projects/unit/mysql-plugin-config.xml
@@ -31,8 +31,8 @@ under the License.
     <plugins>
         <plugin>
             <groupId>com.wakaleo.maven.plugin.schemaspy</groupId>
-            <artifactId>maven-schemaspy-plugin</artifactId>
-            <version>1.0</version>
+            <artifactId>schemaspy-maven-plugin</artifactId>
+            <version>@project.version@</version>
             <configuration>
               <databaseType>mysql</databaseType>
               <database>test</database>

--- a/src/test/projects/unit/oracle-plugin-config.xml
+++ b/src/test/projects/unit/oracle-plugin-config.xml
@@ -31,8 +31,8 @@ under the License.
     <plugins>
         <plugin>
             <groupId>com.wakaleo.maven.plugin.schemaspy</groupId>
-            <artifactId>maven-schemaspy-plugin</artifactId>
-            <version>1.0</version>
+            <artifactId>schemaspy-maven-plugin</artifactId>
+            <version>@project.version@</version>
             <configuration>
               <databaseType>orathin</databaseType>
               <database>xe</database>

--- a/src/test/projects/unit/test-plugin-config.xml
+++ b/src/test/projects/unit/test-plugin-config.xml
@@ -31,8 +31,8 @@ under the License.
     <plugins>
         <plugin>
             <groupId>com.wakaleo.schemaspy</groupId>
-            <artifactId>maven-schemaspy-plugin</artifactId>
-            <version>1.0</version>
+            <artifactId>schemaspy-maven-plugin</artifactId>
+            <version>@project.version@</version>
             <configuration>
               <outputDirectory>target/reports/test</outputDirectory>
               <databaseType>derby</databaseType>


### PR DESCRIPTION
Rename artifactId (maven-schemaspy-plugin -> schemaspy-maven-plugin) to comply with Apache Maven conventions.

Things now build on Java 7/8/9 and are tested with Maven 3.2.5/3.3.9/3.5.0/3.5.2/3.5.3 (see https://travis-ci.org/GeoDienstenCentrum/maven-schemaspy-plugin/builds/351289212 )

close #18